### PR TITLE
feat: TTS Test mode for end-to-end STT testing

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,19 +80,23 @@ async def serve_file(filename: str):
     return FileResponse(path)
 
 
-@fastapi_app.post("/api/tts-transcribe")
-async def tts_transcribe(request: Request):
-    body = await request.json()
-    text = body.get("text", "").strip()
-    tts_model = body.get("tts_model", "aura-2-asteria-en")
-    stt_params = body.get("stt_params", {})
-
-    if not text:
-        return JSONResponse({"error": "text is required"}, status_code=400)
-
-    api_key = os.getenv("DEEPGRAM_API_KEY", "")
+async def _tts_generate(text: str, tts_model: str, api_key: str) -> bytes:
+    """Call Deepgram TTS and return MP3 bytes."""
     headers = {"Authorization": f"Token {api_key}"}
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(
+            "https://api.deepgram.com/v1/speak",
+            headers={**headers, "Content-Type": "application/json"},
+            params={"model": tts_model, "encoding": "mp3"},
+            json={"text": text},
+        )
+        resp.raise_for_status()
+        return resp.content
 
+
+async def _stt_batch(audio_bytes: bytes, stt_params: dict, api_key: str) -> dict:
+    """Transcribe audio bytes via Deepgram pre-recorded (batch) API."""
+    headers = {"Authorization": f"Token {api_key}"}
     clean = clean_params(stt_params, Mode.BATCH)
     query_params = {}
     for k, v in clean.items():
@@ -104,31 +108,88 @@ async def tts_transcribe(request: Request):
             query_params[k] = str(v)
     query_params.setdefault("model", "nova-2")
 
-    try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            # Step 1: TTS — convert text to MP3
-            tts_resp = await client.post(
-                "https://api.deepgram.com/v1/speak",
-                headers={**headers, "Content-Type": "application/json"},
-                params={"model": tts_model, "encoding": "mp3"},
-                json={"text": text},
-            )
-            tts_resp.raise_for_status()
-            audio_bytes = tts_resp.content
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(
+            "https://api.deepgram.com/v1/listen",
+            headers={**headers, "Content-Type": "audio/mp3"},
+            params=query_params,
+            content=audio_bytes,
+        )
+        resp.raise_for_status()
+        return resp.json()
 
-            # Step 2: STT — transcribe the generated audio
-            stt_resp = await client.post(
-                "https://api.deepgram.com/v1/listen",
-                headers={**headers, "Content-Type": "audio/mp3"},
-                params=query_params,
-                content=audio_bytes,
+
+async def _stt_streaming(audio_bytes: bytes, stt_params: dict, api_key: str) -> dict:
+    """Transcribe audio bytes via Deepgram WebSocket streaming API.
+    Chunks the audio and streams it through AsyncDeepgramClient, collecting
+    all final transcript segments. Returns {"transcript": str, "segments": list}.
+    """
+    dg = AsyncDeepgramClient(api_key=api_key)
+    sdk_kwargs = _params_to_sdk_kwargs(stt_params)
+
+    segments = []
+
+    async with dg.listen.v1.connect(**sdk_kwargs) as ws:
+        async def on_message(msg, **kwargs):
+            if isinstance(msg, ListenV1Results) and bool(msg.is_final):
+                t = msg.channel.alternatives[0].transcript
+                if t.strip():
+                    segments.append(t)
+
+        ws.on(EventType.MESSAGE, on_message)
+        listen_task = asyncio.create_task(ws.start_listening())
+
+        chunk_size = 4096
+        for i in range(0, len(audio_bytes), chunk_size):
+            await ws.send_media(audio_bytes[i:i + chunk_size])
+            await asyncio.sleep(0)  # yield to event loop between chunks
+
+        await ws.send_close_stream()
+        await listen_task
+
+    return {
+        "transcript": " ".join(segments),
+        "segments": segments,
+    }
+
+
+@fastapi_app.post("/api/tts-transcribe")
+async def tts_transcribe(request: Request):
+    body = await request.json()
+    text = body.get("text", "").strip()
+    tts_model = body.get("tts_model", "aura-2-asteria-en")
+    stt_params = body.get("stt_params", {})
+    mode = body.get("mode", "batch")  # "batch" | "streaming" | "both"
+
+    if not text:
+        return JSONResponse({"error": "text is required"}, status_code=400)
+    if mode not in ("batch", "streaming", "both"):
+        return JSONResponse({"error": "mode must be batch, streaming, or both"}, status_code=400)
+
+    api_key = os.getenv("DEEPGRAM_API_KEY", "")
+
+    try:
+        audio_bytes = await _tts_generate(text, tts_model, api_key)
+
+        if mode == "batch":
+            result = await _stt_batch(audio_bytes, stt_params, api_key)
+            return JSONResponse(result)
+
+        elif mode == "streaming":
+            result = await _stt_streaming(audio_bytes, stt_params, api_key)
+            return JSONResponse(result)
+
+        else:  # both — run in parallel
+            batch_result, stream_result = await asyncio.gather(
+                _stt_batch(audio_bytes, stt_params, api_key),
+                _stt_streaming(audio_bytes, stt_params, api_key),
             )
-            stt_resp.raise_for_status()
-            return JSONResponse(stt_resp.json())
+            return JSONResponse({"batch": batch_result, "streaming": stream_result})
+
     except httpx.HTTPStatusError as e:
         return JSONResponse({"error": str(e)}, status_code=e.response.status_code)
     except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
+        return JSONResponse({"error": _clean_error(e)}, status_code=500)
 
 
 @fastapi_app.post("/transcribe")

--- a/app.py
+++ b/app.py
@@ -119,13 +119,15 @@ async def _stt_batch(audio_bytes: bytes, stt_params: dict, api_key: str) -> dict
         return resp.json()
 
 
-async def _stt_streaming(audio_bytes: bytes, stt_params: dict, api_key: str) -> dict:
-    """Transcribe audio bytes via Deepgram WebSocket streaming API.
-    Chunks the audio and streams it through AsyncDeepgramClient, collecting
-    all final transcript segments. Returns {"transcript": str, "segments": list}.
+async def _stt_streaming(text: str, tts_model: str, stt_params: dict, api_key: str) -> dict:
+    """Pipe Deepgram TTS streaming response directly into the STT WebSocket.
+    TTS audio chunks are forwarded to STT as they arrive — naturally paced at
+    speech speed, no buffering or artificial timing needed.
+    Returns {"transcript": str, "segments": list}.
     """
     dg = AsyncDeepgramClient(api_key=api_key)
     sdk_kwargs = _params_to_sdk_kwargs(stt_params)
+    headers = {"Authorization": f"Token {api_key}"}
 
     segments = []
 
@@ -139,10 +141,18 @@ async def _stt_streaming(audio_bytes: bytes, stt_params: dict, api_key: str) -> 
         ws.on(EventType.MESSAGE, on_message)
         listen_task = asyncio.create_task(ws.start_listening())
 
-        chunk_size = 4096
-        for i in range(0, len(audio_bytes), chunk_size):
-            await ws.send_media(audio_bytes[i:i + chunk_size])
-            await asyncio.sleep(0)  # yield to event loop between chunks
+        # Stream TTS audio directly into STT WebSocket as chunks arrive
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            async with client.stream(
+                "POST",
+                "https://api.deepgram.com/v1/speak",
+                headers={**headers, "Content-Type": "application/json"},
+                params={"model": tts_model, "encoding": "mp3"},
+                json={"text": text},
+            ) as tts_resp:
+                tts_resp.raise_for_status()
+                async for chunk in tts_resp.aiter_bytes(chunk_size=4096):
+                    await ws.send_media(chunk)
 
         await ws.send_close_stream()
         await listen_task
@@ -169,20 +179,23 @@ async def tts_transcribe(request: Request):
     api_key = os.getenv("DEEPGRAM_API_KEY", "")
 
     try:
-        audio_bytes = await _tts_generate(text, tts_model, api_key)
-
         if mode == "batch":
+            audio_bytes = await _tts_generate(text, tts_model, api_key)
             result = await _stt_batch(audio_bytes, stt_params, api_key)
             return JSONResponse(result)
 
         elif mode == "streaming":
-            result = await _stt_streaming(audio_bytes, stt_params, api_key)
+            result = await _stt_streaming(text, tts_model, stt_params, api_key)
             return JSONResponse(result)
 
-        else:  # both — run in parallel
+        else:  # both — batch buffers TTS bytes, streaming pipes TTS live; run in parallel
+            async def _batch_pipeline():
+                audio_bytes = await _tts_generate(text, tts_model, api_key)
+                return await _stt_batch(audio_bytes, stt_params, api_key)
+
             batch_result, stream_result = await asyncio.gather(
-                _stt_batch(audio_bytes, stt_params, api_key),
-                _stt_streaming(audio_bytes, stt_params, api_key),
+                _batch_pipeline(),
+                _stt_streaming(text, tts_model, stt_params, api_key),
             )
             return JSONResponse({"batch": batch_result, "streaming": stream_result})
 

--- a/static/app.js
+++ b/static/app.js
@@ -27,10 +27,12 @@ function appData() {
     // TTS Test
     ttsText: '',
     ttsModel: 'aura-2-asteria-en',
+    ttsMode: 'batch',   // 'batch' | 'streaming' | 'both'
     ttsLoading: false,
     ttsResult: null,
     ttsLastText: '',
     ttsLastTranscript: '',
+    ttsLastStreamTranscript: '',
 
     // Transcript
     finalTranscript: '',
@@ -443,6 +445,7 @@ function appData() {
           body: JSON.stringify({
             text: this.ttsText,
             tts_model: this.ttsModel,
+            mode: this.ttsMode,
             stt_params: this.getCleanParams('batch'),
           }),
         });
@@ -450,11 +453,20 @@ function appData() {
         if (data.error) throw new Error(data.error);
         this.ttsResult = data;
 
-        const transcript = this.extractBatchTranscript(data);
-        this.ttsLastText = this.ttsText;
-        this.ttsLastTranscript = transcript || '';
-        if (transcript) {
-          this.finalTranscript += this.escapeHtml(transcript) + '\n';
+        // Extract transcripts based on mode
+        const batchSrc  = this.ttsMode === 'both' ? data.batch   : (this.ttsMode === 'batch'     ? data : null);
+        const streamSrc = this.ttsMode === 'both' ? data.streaming : (this.ttsMode === 'streaming' ? data : null);
+
+        const batchTranscript  = batchSrc  ? this.extractBatchTranscript(batchSrc)  : '';
+        const streamTranscript = streamSrc ? (streamSrc.transcript || '')            : '';
+
+        this.ttsLastText             = this.ttsText;
+        this.ttsLastTranscript       = batchTranscript || streamTranscript;
+        this.ttsLastStreamTranscript = streamTranscript;
+
+        const display = batchTranscript || streamTranscript;
+        if (display) {
+          this.finalTranscript += this.escapeHtml(display) + '\n';
         }
         this.addResponse('final', data);
         this.rightTab = 'transcript';

--- a/templates/index.html
+++ b/templates/index.html
@@ -1100,6 +1100,19 @@
                   <div class="field-label">TTS Voice</div>
                   <input class="field-input" x-model="ttsModel" placeholder="aura-2-asteria-en">
                 </div>
+                <div class="field">
+                  <div class="field-label">STT Mode</div>
+                  <div style="display:flex;gap:4px;">
+                    <template x-for="m in ['batch','streaming','both']" :key="m">
+                      <button class="action-btn btn-sm"
+                        :class="ttsMode === m ? 'btn-primary' : 'btn-secondary'"
+                        style="flex:1;text-transform:capitalize;"
+                        @click="ttsMode = m"
+                        x-text="m">
+                      </button>
+                    </template>
+                  </div>
+                </div>
                 <button class="action-btn btn-primary"
                   :disabled="ttsLoading || !ttsText.trim()"
                   @click="runTts()">
@@ -1617,14 +1630,32 @@
                 <span class="diff-label">Sent</span>
                 <span class="diff-text" x-text="ttsLastText"></span>
               </div>
-              <div class="diff-row">
-                <span class="diff-label">Transcribed</span>
-                <span class="diff-text" x-text="ttsLastTranscript || '(empty)'"></span>
-              </div>
-              <div class="diff-row">
-                <span class="diff-label">Difference</span>
-                <span class="diff-text" x-html="renderTtsDiff(ttsLastText, ttsLastTranscript)"></span>
-              </div>
+              <!-- Batch row(s) -->
+              <template x-if="ttsLastTranscript !== '' && (ttsLastStreamTranscript === '' || ttsLastTranscript !== ttsLastStreamTranscript)">
+                <div>
+                  <div class="diff-row">
+                    <span class="diff-label" x-text="ttsLastStreamTranscript ? 'Batch' : 'Transcribed'"></span>
+                    <span class="diff-text" x-text="ttsLastTranscript || '(empty)'"></span>
+                  </div>
+                  <div class="diff-row">
+                    <span class="diff-label" x-text="ttsLastStreamTranscript ? 'Batch diff' : 'Difference'"></span>
+                    <span class="diff-text" x-html="renderTtsDiff(ttsLastText, ttsLastTranscript)"></span>
+                  </div>
+                </div>
+              </template>
+              <!-- Streaming row(s) -->
+              <template x-if="ttsLastStreamTranscript !== ''">
+                <div>
+                  <div class="diff-row" style="margin-top: 4px;">
+                    <span class="diff-label">Streaming</span>
+                    <span class="diff-text" x-text="ttsLastStreamTranscript || '(empty)'"></span>
+                  </div>
+                  <div class="diff-row">
+                    <span class="diff-label">Stream diff</span>
+                    <span class="diff-text" x-html="renderTtsDiff(ttsLastText, ttsLastStreamTranscript)"></span>
+                  </div>
+                </div>
+              </template>
             </div>
           </template>
 


### PR DESCRIPTION
## Summary

Adds a **TTS Test mode** for end-to-end STT testing without a microphone. Type text, generate speech via Deepgram TTS, and transcribe through the STT pipeline with your current param settings.

## What's included

**Backend — `POST /api/tts-transcribe`**
- `mode: batch` — TTS → MP3 bytes → pre-recorded `/v1/listen`
- `mode: streaming` — TTS HTTP stream piped **live** into STT WebSocket (`wss://`) as chunks arrive, naturally paced at speech speed
- `mode: both` — batch + streaming run in parallel via `asyncio.gather`

**UI**
- New TTS Test tab with text area, voice selector, and 3-way mode toggle (Batch / Streaming / Both)
- Auto-switches to Transcript tab after each run
- TTS Comparison panel: Sent / Transcribed / Difference (word-level LCS diff — deletions red, insertions green, replacements old→new)
- In `both` mode, shows separate diff rows for batch and streaming results

**Docs**
- README updated with feature description, screenshot, and curl API example

## Test plan

- [ ] Batch mode: enter text, transcribe, diff appears
- [ ] Streaming mode: enter PII text with redaction enabled, confirm `[redacted]` in output
- [ ] Both mode: two diff rows shown (Batch / Streaming)
- [ ] `POST /api/tts-transcribe` via curl returns valid JSON for all three modes
- [ ] URL bar shows TTS speak endpoint when in TTS Test tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)